### PR TITLE
Add MeshCollider functionality to Hex

### DIFF
--- a/Assets/Scripts/HexTile.cs
+++ b/Assets/Scripts/HexTile.cs
@@ -12,7 +12,16 @@ public class HexTile : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        // Check whether a MeshFilter or MeshCollider exist on the Hex. If at least one of them does, then generate the
+        // mesh.
         MeshFilter meshFilter = gameObject.GetComponent<MeshFilter>();
+        MeshCollider meshCollider = gameObject.GetComponent<MeshCollider>();
+        if (meshFilter || meshCollider)
+        {
+            mesh = GenerateMesh();
+        }
+        
+        // If the MeshFilter exists, assign the generated mesh.
         if (!meshFilter)
         {
             Debug.LogWarning("HexTile at position " + pos + " has no MeshFilter. It will not be visible in " +
@@ -20,9 +29,18 @@ public class HexTile : MonoBehaviour
         }
         else
         {
-            Debug.Log("Mesh filter found. Generating mesh.");
-            mesh = GenerateMesh();
             meshFilter.mesh = mesh;
+        }
+
+        // If the MeshCollider exists, assign the generated mesh.
+        if (!meshCollider)
+        {
+            Debug.Log("HexTile at position " + pos + " has no MeshCollider.");
+        }
+        else
+        {
+            Debug.Log("MeshCollider found, adding Mesh.");
+            meshCollider.sharedMesh = mesh;
         }
     }
 

--- a/Assets/Scripts/HexTile.cs
+++ b/Assets/Scripts/HexTile.cs
@@ -33,13 +33,8 @@ public class HexTile : MonoBehaviour
         }
 
         // If the MeshCollider exists, assign the generated mesh.
-        if (!meshCollider)
+        if (meshCollider) 
         {
-            Debug.Log("HexTile at position " + pos + " has no MeshCollider.");
-        }
-        else
-        {
-            Debug.Log("MeshCollider found, adding Mesh.");
             meshCollider.sharedMesh = mesh;
         }
     }


### PR DESCRIPTION
If a MeshCollider exists on the same GameObject as HexTile, then HexTile will set the collider's `sharedMesh` to the one it generated.

Added tests to HexTile to verify collision works.