### PR TITLE
Fix package name in manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ crashlytics-build.properties
 
 # Doxygen
 Doxy*
+
+# Tarball packaging
+.npmignore
+

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "com.michaeljbradley",
+    "name": "com.michaeljbradley.hex-grid",
     "version": "0.1.0",
     "description": "A package to implement hexagonal grids in Unity projects.",
     "displayName": "Hex Grid",


### PR DESCRIPTION
Package name was missing the suffix `hex-grid`