### PR TITLE
Add HexTile property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ This package does not exist in a registry. The two options are either
 
 Hex Grid has been tested with Unity 2021.3.2f1, but may be compatible with other releases.
 
+### Dependencies
+
+Hex Grid depends on the
+[SerializableDictionaryLite](https://openupm.com/packages/com.rotaryheart.serializabledictionarylite/)
+package to display dictionaries in the editor. 
+
 ## Workflows
 
 ### Generating a grid

--- a/Runtime/Hex/HexTile.cs
+++ b/Runtime/Hex/HexTile.cs
@@ -10,7 +10,7 @@ public class HexTile : MonoBehaviour
     public Mesh mesh;
 
     public Vector3 center;
-    
+
     // Start is called before the first frame update
     void Start()
     {
@@ -55,5 +55,85 @@ public class HexTile : MonoBehaviour
         ret.uv = HexUv.GetUvMapping(uvType);
         
         return ret;
+    }
+    
+    private IHexTileProperties<int> propertyInt32;
+
+    /// <summary>
+    /// A convenience property to get and set int properties.
+    /// 
+    /// If propertySingle is null, it loads the Component from the GameObject
+    /// and saves a reference to it.
+    /// </summary>
+    public IHexTileProperties<int> PropertyInt32 {
+        get
+        {
+            if (propertyInt32 == null) {
+                propertyInt32 = GetComponent<IHexTileProperties<int>>();
+            }
+            return propertyInt32;
+        }
+
+        set
+        {
+            propertyInt32 = value;
+        }
+    }
+
+    private IHexTileProperties<float> propertySingle;
+
+    /// <summary>
+    /// A convenience property to get and set float properties.
+    /// 
+    /// If propertySingle is null, it loads the Component from the GameObject
+    /// and saves a reference to it.
+    /// </summary>
+    public IHexTileProperties<float> PropertySingle {
+        get
+        {
+            if (propertySingle == null) {
+                propertySingle = GetComponent<IHexTileProperties<float>>();
+            }
+            return propertySingle;
+        }
+
+        set
+        {
+            propertySingle = value;
+        }
+    }
+
+    private IHexTileProperties<bool> propertyBoolean;
+    /// <summary>
+    /// A convenience property to get and set boolean properties. 
+    /// 
+    /// If propertyBoolean is null, it loads the Component from the GameObject
+    /// and saves a reference to it.
+    /// </summary>
+    public IHexTileProperties<bool> PropertyBoolean {
+        get
+        {
+            if (propertyBoolean == null) {
+                propertyBoolean = GetComponent<IHexTileProperties<bool>>();
+            }
+            return propertyBoolean;
+        }
+
+        set
+        {
+            propertyBoolean = value;
+        }
+    }
+
+    /// <summary>
+    /// Convenience method to retrieve an IHexTileProperty component from this
+    /// GameObject.
+    ///
+    /// There is no caching involved, this method is purely for convenience.
+    /// </summary>
+    /// <typeparam name="T">The type of property to retrieve.</typeparam>
+    /// <returns>The retrieved IHexTileProperty</returns>
+    public IHexTileProperties<T> GetProperty<T>() {
+        return GetComponent<IHexTileProperties<T>>();
     }
 }

--- a/Runtime/Hex/Properties.meta
+++ b/Runtime/Hex/Properties.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8569754e503ea4321b20fc8ac4827061
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Hex/Properties/HexTilePropertiesBoolean.cs
+++ b/Runtime/Hex/Properties/HexTilePropertiesBoolean.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class HexTilePropertiesBoolean : MonoBehaviour, IHexTileProperties<bool>
+{
+    public DictBoolean properties = new DictBoolean();
+
+    public bool this[string propertyName] {
+        get {
+            return properties[propertyName];
+        }
+        set {
+            properties[propertyName] = value;
+        }
+    }
+}

--- a/Runtime/Hex/Properties/HexTilePropertiesBoolean.cs.meta
+++ b/Runtime/Hex/Properties/HexTilePropertiesBoolean.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2eec440c3cde4f519f5747f35bbbfa3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Hex/Properties/HexTilePropertiesInt32.cs
+++ b/Runtime/Hex/Properties/HexTilePropertiesInt32.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class HexTilePropertiesInt32 : MonoBehaviour, IHexTileProperties<int>
+{
+    public DictInt32 properties = new DictInt32();
+
+    public int this[string propertyName] {
+        get {
+            return properties[propertyName];
+        }
+        set {
+            properties[propertyName] = value;
+        }
+    }
+}

--- a/Runtime/Hex/Properties/HexTilePropertiesInt32.cs.meta
+++ b/Runtime/Hex/Properties/HexTilePropertiesInt32.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b583c5f5f9abf4d89a6a21a6260a84f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Hex/Properties/HexTilePropertiesSingle.cs
+++ b/Runtime/Hex/Properties/HexTilePropertiesSingle.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class HexTilePropertiesSingle : MonoBehaviour, IHexTileProperties<float>
+{
+    public DictSingle properties = new DictSingle();
+
+    public float this[string propertyName] {
+        get {
+            return properties[propertyName];
+        }
+        set {
+            properties[propertyName] = value;
+        }
+    }
+}

--- a/Runtime/Hex/Properties/HexTilePropertiesSingle.cs.meta
+++ b/Runtime/Hex/Properties/HexTilePropertiesSingle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32e8ce3232dab44d08dd9c026085356d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Hex/Properties/IHexTileProperties.cs
+++ b/Runtime/Hex/Properties/IHexTileProperties.cs
@@ -1,0 +1,5 @@
+
+public interface IHexTileProperties<T>
+{
+    public T this[string propertyName] { get; set; }
+}

--- a/Runtime/Hex/Properties/IHexTileProperties.cs.meta
+++ b/Runtime/Hex/Properties/IHexTileProperties.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a064cf8a3c3b94566ae3e1954da018a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Hex/Properties/SerializableDictionaries.cs
+++ b/Runtime/Hex/Properties/SerializableDictionaries.cs
@@ -1,0 +1,6 @@
+using System;
+using RotaryHeart.Lib.SerializableDictionary;
+
+[Serializable] public class DictInt32 : SerializableDictionaryBase<string, int> { }
+[Serializable] public class DictSingle : SerializableDictionaryBase<string, float> { }
+[Serializable] public class DictBoolean : SerializableDictionaryBase<string, bool> { }

--- a/Runtime/Hex/Properties/SerializableDictionaries.cs.meta
+++ b/Runtime/Hex/Properties/SerializableDictionaries.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0655bcac8a59946f6b4ff025da84840a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/com.MichaelJBradley.HexGrid.asmdef
+++ b/Runtime/com.MichaelJBradley.HexGrid.asmdef
@@ -2,9 +2,7 @@
     "name": "com.MichaelJBradley.HexGrid",
     "rootNamespace": "",
     "references": [
-        "GUID:f92c1ebeae7f54a9fa569258458aca3e",
-        "GUID:44d516056ed0a4887a87bd64133799a4",
-        "GUID:09bbe569886d2460d8af700253172281"
+        "GUID:f6772791f1e9e2041b58a4d8602de722"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/Runtime/HexTilePropertyTest.cs
+++ b/Tests/Runtime/HexTilePropertyTest.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class HexTilePropertyTest
+{
+    // A Test behaves as an ordinary method
+    [Test]
+    public void HexTilePropertyTestSimplePasses()
+    {
+        // Use the Assert class to test conditions
+    }
+
+    // A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
+    // `yield return null;` to skip a frame.
+    [UnityTest]
+    public IEnumerator HexTilePropertyTestWithEnumeratorPasses()
+    {
+        // Use the Assert class to test conditions.
+        // Use yield to skip a frame.
+        yield return null;
+    }
+}

--- a/Tests/Runtime/HexTilePropertyTest.cs.meta
+++ b/Tests/Runtime/HexTilePropertyTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22d79deb4f0c0446c90cb81bfe4fb0ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/HexTileTests.cs
+++ b/Tests/Runtime/HexTileTests.cs
@@ -56,28 +56,97 @@ namespace Tests
     
         [UnityTest]
         public IEnumerator HexTile_WithMeshCollider_AboveFallingBall_DoesNotCollide() {
-                // Create the ball that will collide with the Hex.
-                // Put it above the Hex, so it can fall onto it.
-                GameObject ball = new GameObject();
-                ball.transform.position = new Vector3(0, -4, 0);
-                ball.AddComponent<SphereCollider>();
-                Ball ballScript = ball.AddComponent<Ball>();
-                Rigidbody ballRb = ball.AddComponent<Rigidbody>();
-                ballRb.useGravity = true;
-                
-                // Create the Hex
-                GameObject h = new GameObject();
-                h.AddComponent<MeshCollider>();
-                HexTile ht = h.AddComponent<HexTile>();
-                ht.pos = new Hex(0, 0);
-                ht.vertices = HexVertices.FlatTop;
-                ht.triangles = flatTopTriangles;
-                
-                yield return new WaitForSeconds(1f);
+            // Create the ball that will collide with the Hex.
+            // Put it above the Hex, so it can fall onto it.
+            GameObject ball = new GameObject();
+            ball.transform.position = new Vector3(0, -4, 0);
+            ball.AddComponent<SphereCollider>();
+            Ball ballScript = ball.AddComponent<Ball>();
+            Rigidbody ballRb = ball.AddComponent<Rigidbody>();
+            ballRb.useGravity = true;
+            
+            // Create the Hex
+            GameObject h = new GameObject();
+            h.AddComponent<MeshCollider>();
+            HexTile ht = h.AddComponent<HexTile>();
+            ht.pos = new Hex(0, 0);
+            ht.vertices = HexVertices.FlatTop;
+            ht.triangles = flatTopTriangles;
+            
+            yield return new WaitForSeconds(1f);
 
-                MeshCollider mc = h.GetComponent<MeshCollider>();
-                Assert.That(mc, Is.Not.Null);
-                Assert.That(ballScript.collision, Is.False);
+            MeshCollider mc = h.GetComponent<MeshCollider>();
+            Assert.That(mc, Is.Not.Null);
+            Assert.That(ballScript.collision, Is.False);
+        }
+
+        [Test]
+        public void HexTile_WithPropertyInt32_GetsComponent() {
+            GameObject h = new GameObject();
+            HexTile ht = h.AddComponent<HexTile>();
+            HexTilePropertiesInt32 p = h.AddComponent<HexTilePropertiesInt32>();
+            p["SomeProperty"] = 568;
+
+            IHexTileProperties<int> actual = ht.PropertyInt32;
+
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual["SomeProperty"], Is.EqualTo(568));
+        }
+
+        [Test]
+        public void HexTile_WithoutPropertyInt32_ReturnsNull() {
+            GameObject h = new GameObject();
+            HexTile ht = h.AddComponent<HexTile>();
+
+            IHexTileProperties<int> actual = ht.PropertyInt32;
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void HexTile_WithPropertySingle_GetsComponent() {
+            GameObject h = new GameObject();
+            HexTile ht = h.AddComponent<HexTile>();
+            HexTilePropertiesSingle p = h.AddComponent<HexTilePropertiesSingle>();
+            p["SomeProperty"] = 12.4f;
+
+            IHexTileProperties<float> actual = ht.PropertySingle;
+
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual["SomeProperty"], Is.EqualTo(12.4f));
+        }
+
+        [Test]
+        public void HexTile_WithoutPropertySingle_ReturnsNull() {
+            GameObject h = new GameObject();
+            HexTile ht = h.AddComponent<HexTile>();
+
+            IHexTileProperties<float> actual = ht.PropertySingle;
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void HexTile_WithPropertyBoolean_GetsComponent() {
+            GameObject h = new GameObject();
+            HexTile ht = h.AddComponent<HexTile>();
+            HexTilePropertiesBoolean p = h.AddComponent<HexTilePropertiesBoolean>();
+            p["SomeProperty"] = true;
+
+            IHexTileProperties<bool> actual = ht.PropertyBoolean;
+
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual["SomeProperty"], Is.True);
+        }
+
+        [Test]
+        public void HexTile_WithoutPropertyBoolean_ReturnsNull() {
+            GameObject h = new GameObject();
+            HexTile ht = h.AddComponent<HexTile>();
+
+            IHexTileProperties<bool> actual = ht.PropertyBoolean;
+
+            Assert.That(actual, Is.Null);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.michaeljbradley.hex-grid",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "A package to implement hexagonal grids in Unity projects.",
     "displayName": "Hex Grid",
     "unity": "2021.3",
@@ -13,6 +13,9 @@
     "keywords": ["hex", "hexagonal", "hexagon", "generator", "map", "grid"],
     "license": "MIT",
     "licenseUrl": "https://github.com/MichaelJBradley/hex-grid/blob/master/LICENSE.md",
+    "dependencies": {
+        "com.rotaryheart.serializabledictionarylite": "2.6.11"
+    },
     "samples": [
         {
             "displayName": "Pistons on hexes",


### PR DESCRIPTION
Allow users to define their own properties for HexTiles. To ease use, HexTile supports quick references to and caching of three of the most common property types (int, bool and float).

* Update readme to include notes about new dependency on [SerializableDictionaryLite](https://www.rotaryheart.com/Wiki/SerializableDictionaryLite.html)
* Add `IHexTileProperties<T>` interface
* Add implementations of `IHexTileProperties` for commonly used types
  * Add implementations of `SerializableDictionaryBase` for the same types
* Update `HexTile` with convenience methods to get properties
* Add new sample to demonstrate HexTile properties